### PR TITLE
Remove sentence transformer dependency from hybrid chunker

### DIFF
--- a/docs/HYBRID_CHUNKER.md
+++ b/docs/HYBRID_CHUNKER.md
@@ -7,7 +7,7 @@ The **Hybrid Chunker** is an advanced text chunking strategy that combines multi
 ## Features
 
 ### 🧠 **Semantic Chunking**
-- Uses **Sentence Transformers** to measure semantic similarity between text segments
+- Uses **OpenAI embeddings via Universal API** to measure semantic similarity
 - Groups semantically related content together
 - Configurable similarity threshold for fine-tuning
 
@@ -63,8 +63,8 @@ The **Hybrid Chunker** is an advanced text chunking strategy that combines multi
   - Lower values = larger chunks, less strict semantic grouping
 
 - `use_semantic_chunking`: Enable semantic similarity-based chunking (default: true)
-  - Requires sentence-transformers library
-  - Falls back to structural chunking if disabled or unavailable
+  - Uses OpenAI embeddings through the built-in Universal API embedder
+  - Falls back to structural chunking if API credentials are missing
 
 - `use_document_structure`: Use document structure for chunking (default: true)
   - Recognizes headers, paragraphs, lists
@@ -107,7 +107,7 @@ The **Hybrid Chunker** is an advanced text chunking strategy that combines multi
 }
 ```
 
-### 2. MemReader Configuration
+### 2. MemReader Configuration (OpenAI embeddings)
 
 ```json
 {
@@ -119,7 +119,8 @@ The **Hybrid Chunker** is an advanced text chunking strategy that combines multi
         "tokenizer_or_token_counter": "gpt2",
         "semantic_similarity_threshold": 0.8,
         "use_semantic_chunking": true,
-        "overlap_strategy": "fixed"
+        "overlap_strategy": "fixed",
+        "openai_embedding_model": "text-embedding-3-large"  
       }
     }
   }
@@ -156,7 +157,7 @@ chunks = chunker.chunk(your_text)
 The Hybrid Chunker requires the following additional packages:
 
 ```bash
-pip install sentence-transformers numpy transformers
+pip install numpy transformers
 ```
 
 ### Optional Dependencies
@@ -219,8 +220,8 @@ pip install sentence-transformers numpy transformers
 
 ### Common Issues
 
-1. **"Could not load sentence-transformers"**
-   - Install: `pip install sentence-transformers`
+1. **"OpenAI API key missing"**
+   - Set `OPENAI_API_KEY` environment variable or configure `openai_api_key` in chunker config
    - Will fallback to structural chunking
 
 2. **"Tokenizer not found"** 

--- a/src/memos/chunkers/hybrid_chunker.py
+++ b/src/memos/chunkers/hybrid_chunker.py
@@ -2,18 +2,20 @@
 Hybrid Text Chunker combining multiple chunking strategies.
 
 This chunker implements a sophisticated approach that combines:
-1. Semantic similarity-based chunking using sentence transformers
+1. Semantic similarity-based chunking using OpenAI embeddings via the Universal API
 2. Document structure awareness (headers, paragraphs, lists)
 3. Adaptive overlap based on content similarity
 4. Fallback to sentence/character-based chunking
 """
 
+import os
 import re
 import numpy as np
 from typing import List, Optional, Tuple
-from sentence_transformers import SentenceTransformer
 
 from memos.configs.chunker import HybridChunkerConfig
+from memos.embedders.universal_api import UniversalAPIEmbedder
+from memos.configs.embedder import UniversalAPIEmbedderConfig
 from memos.dependency import require_python_package
 from memos.log import get_logger
 
@@ -29,11 +31,6 @@ class HybridChunker(BaseChunker):
     """
 
     @require_python_package(
-        import_name="sentence_transformers",
-        install_command="pip install sentence-transformers",
-        install_link="https://www.sbert.net/docs/installation.html",
-    )
-    @require_python_package(
         import_name="numpy",
         install_command="pip install numpy",
         install_link="https://numpy.org/install/",
@@ -41,18 +38,34 @@ class HybridChunker(BaseChunker):
     def __init__(self, config: HybridChunkerConfig):
         self.config = config
         
-        # Initialize sentence transformer for semantic similarity
+        # Initialize OpenAI embedder for semantic similarity via Universal API
+        self.embedder = None
         if config.use_semantic_chunking:
             try:
-                # Use a lightweight but effective model for semantic similarity
-                self.embedder = SentenceTransformer('all-MiniLM-L6-v2')
-                logger.info("Initialized SentenceTransformer for semantic chunking")
+                api_key = config.openai_api_key or os.getenv("OPENAI_API_KEY")
+                base_url = config.openai_base_url or os.getenv("OPENAI_BASE_URL") or "https://api.openai.com/v1"
+                model_name = (
+                    config.openai_embedding_model
+                    or os.getenv("OPENAI_EMBED_MODEL")
+                    or "text-embedding-3-small"
+                )
+                if not api_key:
+                    raise RuntimeError("Missing OpenAI API key for semantic chunking")
+
+                embedder_cfg = UniversalAPIEmbedderConfig(
+                    provider="openai",
+                    api_key=api_key,
+                    base_url=base_url,
+                    model_name_or_path=model_name,
+                )
+                self.embedder = UniversalAPIEmbedder(embedder_cfg)
+                logger.info("Initialized OpenAI UniversalAPIEmbedder for semantic chunking")
             except Exception as e:
-                logger.warning(f"Failed to initialize SentenceTransformer: {e}. Falling back to structural chunking only.")
+                logger.warning(
+                    f"Failed to initialize OpenAI embedder for semantic chunking: {e}. Falling back to structural chunking only."
+                )
                 self.embedder = None
                 config.use_semantic_chunking = False
-        else:
-            self.embedder = None
 
         # Initialize tokenizer for length calculations
         try:
@@ -189,7 +202,7 @@ class HybridChunker(BaseChunker):
         
         # Get embeddings for all segments
         try:
-            embeddings = self.embedder.encode(segments)
+            embeddings = self.embedder.embed(segments)
             
             chunks = []
             current_chunk = segments[0]

--- a/src/memos/chunkers/hybrid_chunker.py
+++ b/src/memos/chunkers/hybrid_chunker.py
@@ -47,7 +47,7 @@ class HybridChunker(BaseChunker):
                 model_name = (
                     config.openai_embedding_model
                     or os.getenv("OPENAI_EMBED_MODEL")
-                    or "text-embedding-3-small"
+                    or "text-embedding-3-large"
                 )
                 if not api_key:
                     raise RuntimeError("Missing OpenAI API key for semantic chunking")

--- a/src/memos/configs/chunker.py
+++ b/src/memos/configs/chunker.py
@@ -1,4 +1,4 @@
-THIS SHOULD BE A LINTER ERRORfrom typing import Any, ClassVar
+from typing import Any, ClassVar
 
 from pydantic import Field, field_validator, model_validator
 
@@ -50,7 +50,7 @@ class HybridChunkerConfig(BaseChunkerConfig):
         default=None, description="Base URL for OpenAI embeddings (falls back to env OPENAI_BASE_URL or https://api.openai.com/v1)"
     )
     openai_embedding_model: str = Field(
-        default="text-embedding-3-small", description="OpenAI embedding model for semantic chunking (falls back to env OPENAI_EMBED_MODEL)"
+        default="text-embedding-3-large", description="OpenAI embedding model for semantic chunking (falls back to env OPENAI_EMBED_MODEL)"
     )
 
 

--- a/src/memos/configs/chunker.py
+++ b/src/memos/configs/chunker.py
@@ -1,4 +1,4 @@
-from typing import Any, ClassVar
+THIS SHOULD BE A LINTER ERRORfrom typing import Any, ClassVar
 
 from pydantic import Field, field_validator, model_validator
 
@@ -40,6 +40,17 @@ class HybridChunkerConfig(BaseChunkerConfig):
     )
     overlap_strategy: str = Field(
         default="adaptive", description="Overlap strategy: 'fixed', 'adaptive', 'semantic'"
+    )
+
+    # Optional OpenAI embedding settings for semantic chunking via Universal API
+    openai_api_key: str | None = Field(
+        default=None, description="OpenAI API key for semantic chunking (falls back to env OPENAI_API_KEY)"
+    )
+    openai_base_url: str | None = Field(
+        default=None, description="Base URL for OpenAI embeddings (falls back to env OPENAI_BASE_URL or https://api.openai.com/v1)"
+    )
+    openai_embedding_model: str = Field(
+        default="text-embedding-3-small", description="OpenAI embedding model for semantic chunking (falls back to env OPENAI_EMBED_MODEL)"
     )
 
 


### PR DESCRIPTION
## Description

Summary: Refactored `HybridChunker` to utilize OpenAI embeddings via the Universal API for semantic chunking, removing the dependency on `sentence-transformers`. Added optional OpenAI configuration parameters to `HybridChunkerConfig` and set `text-embedding-3-large` as the default embedding model. The chunker now gracefully falls back to structural-only chunking if OpenAI API credentials are not provided. Updated `docs/HYBRID_CHUNKER.md` to reflect these changes.

Fix: N/A

Docs Issue/PR: N/A (docs updated directly)

Reviewer: @(reviewer)

## Checklist:

- [ ] I have performed a self-review of my own code | 我已自行检查了自己的代码
- [ ] I have commented my code in hard-to-understand areas | 我已在难以理解的地方对代码进行了注释
- [ ] I have added tests that prove my fix is effective or that my feature works | 我已添加测试以证明我的修复有效或功能正常
- [ ] I have created related documentation issue/PR in [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) (if applicable) | 我已在 [MemOS-Docs](https://github.com/MemTensor/MemOS-Docs) 中创建了相关的文档 issue/PR（如果适用）
- [ ] I have linked the issue to this PR (if applicable) | 我已将 issue 链接到此 PR（如果适用）
- [ ] I have mentioned the person who will review this PR | 我已提及将审查此 PR 的人

---
<a href="https://cursor.com/background-agent?bcId=bc-ede7a07c-be08-4066-be2c-cb37956c9c88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ede7a07c-be08-4066-be2c-cb37956c9c88">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

